### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Rust implementation of [`Bitswap`] protocol for [`libp2p`].
 
 
-[`Bitswap`]: https://specs.ipfs.tech/bitswap-protocolo/
+[`Bitswap`]: https://specs.ipfs.tech/bitswap-protocol/
 [`libp2p`]: https://docs.rs/libp2p


### PR DESCRIPTION
typo in link of bitswap page