### PR TITLE
chore: Removed unneeded Send/Sync constrains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,11 +389,10 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bff157a9c999bf0a39ca45e0b62076aa27135012cfbf9cc54ad1cf971876f0"
+checksum = "359816e624b0ab1d2ecaef2a07d3820d7078a16ad55f1f1c381422971c418acf"
 dependencies = [
- "async-trait",
  "cid",
  "dashmap",
  "multihash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Implementation of bitswap protocol for libp2p"
 [dependencies]
 async-trait = "0.1"
 asynchronous-codec = "0.7"
-blockstore = "0.1"
+blockstore = "0.3"
 bytes = "1"
 cid = "0.11"
 fnv = "1.0.5"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,7 +20,7 @@ use crate::{Behaviour, Error, Result};
 /// # }
 pub struct BehaviourBuilder<const S: usize, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     protocol_prefix: Option<String>,
     blockstore: B,
@@ -30,7 +30,7 @@ where
 
 impl<const S: usize, B> BehaviourBuilder<S, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     /// Creates a new builder for [`Behaviour`].
     pub(crate) fn new(blockstore: B) -> Self {

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,7 +63,7 @@ enum TaskResult<const S: usize> {
 #[derive(Debug)]
 pub(crate) struct ClientBehaviour<const S: usize, B>
 where
-    B: Blockstore + Send + Sync,
+    B: Blockstore,
 {
     store: Arc<B>,
     protocol: StreamProtocol,
@@ -97,7 +97,7 @@ pub enum SendingState {
 
 impl<const S: usize, B> ClientBehaviour<S, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     pub(crate) fn new(config: ClientConfig, store: Arc<B>, protocol_prefix: Option<&str>) -> Self {
         let protocol = stream_protocol(protocol_prefix, "/ipfs/bitswap/1.2.0")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::client::QueryId;
 #[derive(Debug)]
 pub struct Behaviour<const MAX_MULTIHASH_SIZE: usize, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     protocol: StreamProtocol,
     client: ClientBehaviour<MAX_MULTIHASH_SIZE, B>,
@@ -95,7 +95,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl<const MAX_MULTIHASH_SIZE: usize, B> Behaviour<MAX_MULTIHASH_SIZE, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     /// Creates a new [`Behaviour`] with the default configuration.
     pub fn new(blockstore: B) -> Behaviour<MAX_MULTIHASH_SIZE, B> {
@@ -122,7 +122,7 @@ where
 
 impl<const MAX_MULTIHASH_SIZE: usize, B> NetworkBehaviour for Behaviour<MAX_MULTIHASH_SIZE, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     type ConnectionHandler = ConnHandler<MAX_MULTIHASH_SIZE>;
     type ToSwarm = Event;

--- a/src/server.rs
+++ b/src/server.rs
@@ -133,7 +133,7 @@ impl<const S: usize> PeerWantlist<S> {
 
 impl<const S: usize, B> ServerBehaviour<S, B>
 where
-    B: Blockstore + Send + Sync + 'static,
+    B: Blockstore + 'static,
 {
     pub(crate) fn new(store: Arc<B>, protocol_prefix: Option<&str>) -> Self {
         let protocol = stream_protocol(protocol_prefix, "/ipfs/bitswap/1.2.0")


### PR DESCRIPTION
`Blockstore` requests `Send`/`Sync` constrains on its definition. So we don't need them here.