### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change all error/warn logs to debug ([#47](https://github.com/eigerco/beetswap/pull/47))
 
 ### Fixed
-- Upgrade time crate to fix rust-lang/rust[#125319](https://github.com/eigerco/beetswap/pull/125319) ([#48](https://github.com/eigerco/beetswap/pull/48))
-- *(doc)* rename doc_cfg guard to docsrs, rust-lang/cargo[#13875](https://github.com/eigerco/beetswap/pull/13875) ([#45](https://github.com/eigerco/beetswap/pull/45))
+- Upgrade time crate to fix [rust-lang/rust#125319](https://github.com/rust-lang/rust/issues/125319) ([#48](https://github.com/eigerco/beetswap/pull/48))
+- *(doc)* rename doc_cfg guard to docsrs, [rust-lang/cargo#13875](https://github.com/rust-lang/cargo/issues/13875) ([#45](https://github.com/eigerco/beetswap/pull/45))
 
 ## [0.1.0](https://github.com/eigerco/beetswap/releases/tag/v0.1.0) - 2024-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/eigerco/beetswap/compare/v0.1.0...v0.1.1) - 2024-06-12
+
+### Added
+- Change all error/warn logs to debug ([#47](https://github.com/eigerco/beetswap/pull/47))
+
+### Fixed
+- Upgrade time crate to fix rust-lang/rust[#125319](https://github.com/eigerco/beetswap/pull/125319) ([#48](https://github.com/eigerco/beetswap/pull/48))
+- *(doc)* rename doc_cfg guard to docsrs, rust-lang/cargo[#13875](https://github.com/eigerco/beetswap/pull/13875) ([#45](https://github.com/eigerco/beetswap/pull/45))
+
 ## [0.1.0](https://github.com/eigerco/beetswap/releases/tag/v0.1.0) - 2024-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beetswap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beetswap"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of bitswap protocol for libp2p"


### PR DESCRIPTION
## 🤖 New release
* `beetswap`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/eigerco/beetswap/compare/v0.1.0...v0.1.1) - 2024-06-12

### Added
- Change all error/warn logs to debug ([#47](https://github.com/eigerco/beetswap/pull/47))

### Fixed
- Upgrade time crate to fix rust-lang/rust[#125319](https://github.com/eigerco/beetswap/pull/125319) ([#48](https://github.com/eigerco/beetswap/pull/48))
- *(doc)* rename doc_cfg guard to docsrs, rust-lang/cargo[#13875](https://github.com/eigerco/beetswap/pull/13875) ([#45](https://github.com/eigerco/beetswap/pull/45))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).