### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/eigerco/beetswap/compare/v0.1.1...v0.2.0) - 2024-07-25
+
+### Added
+- [**breaking**] Accept Arc to allow shared blockstore ([#49](https://github.com/eigerco/beetswap/pull/49))
+
 ## [0.1.1](https://github.com/eigerco/beetswap/compare/v0.1.0...v0.1.1) - 2024-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beetswap"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beetswap"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of bitswap protocol for libp2p"


### PR DESCRIPTION
## 🤖 New release
* `beetswap`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/eigerco/beetswap/compare/v0.1.1...v0.2.0) - 2024-07-25

### Added
- [**breaking**] Accept Arc to allow shared blockstore ([#49](https://github.com/eigerco/beetswap/pull/49))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).