### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/eigerco/beetswap/compare/v0.2.0...v0.3.0) - 2024-08-12
+
+### Other
+- Replace `instant` with `web-time` crate ([#52](https://github.com/eigerco/beetswap/pull/52))
+- [**breaking**] Upgrade to libp2p 0.54 ([#51](https://github.com/eigerco/beetswap/pull/51))
+- Make readme presentable ([#53](https://github.com/eigerco/beetswap/pull/53))
+- Fix doc-lazy-continuations clippy CI ([#54](https://github.com/eigerco/beetswap/pull/54))
+
 ## [0.2.0](https://github.com/eigerco/beetswap/compare/v0.1.1...v0.2.0) - 2024-07-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beetswap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beetswap"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of bitswap protocol for libp2p"


### PR DESCRIPTION
## 🤖 New release
* `beetswap`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/eigerco/beetswap/compare/v0.2.0...v0.3.0) - 2024-08-12

### Other
- Replace `instant` with `web-time` crate ([#52](https://github.com/eigerco/beetswap/pull/52))
- [**breaking**] Upgrade to libp2p 0.54 ([#51](https://github.com/eigerco/beetswap/pull/51))
- Make readme presentable ([#53](https://github.com/eigerco/beetswap/pull/53))
- Fix doc-lazy-continuations clippy CI ([#54](https://github.com/eigerco/beetswap/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).