### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/eigerco/beetswap/compare/v0.3.1...v0.4.0) - 2024-09-16
+
+### Other
+
+- [**breaking**] Upgrade blockstore ([#58](https://github.com/eigerco/beetswap/pull/58))
+
 ## [0.3.1](https://github.com/eigerco/beetswap/compare/v0.3.0...v0.3.1) - 2024-08-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beetswap"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beetswap"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of bitswap protocol for libp2p"


### PR DESCRIPTION
## 🤖 New release
* `beetswap`: 0.3.1 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/eigerco/beetswap/compare/v0.3.1...v0.4.0) - 2024-09-16

### Other

- [**breaking**] Upgrade blockstore ([#58](https://github.com/eigerco/beetswap/pull/58))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).