### PR TITLE
extend `START_SENDING_TIMEOUT` to 12 seconds

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ use crate::{Error, Event, Result, ToBehaviourEvent, ToHandlerEvent};
 
 const SEND_FULL_INTERVAL: Duration = Duration::from_secs(30);
 const RECEIVE_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
-const START_SENDING_TIMEOUT: Duration = Duration::from_secs(5);
+const START_SENDING_TIMEOUT: Duration = Duration::from_secs(12);
 
 /// ID of an ongoing query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
When the timeout is shorter than 10 seconds, server cannot source bits from a browser that dialed it.

Extending the timeout past 10 seconds results in beetswap that can get bits from the browser (which is amazing, amirite?).

Fixes: https://github.com/eigerco/beetswap/issues/63