### PR TITLE
fix: Print payload size instead of content to avoid large `Debug` size for `Event`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
-use core::fmt;
+use std::fmt;
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,13 +77,13 @@ pub enum Event {
 struct DataFmt<'a>(&'a [u8]);
 
 impl<'a> fmt::Debug for DataFmt<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("[... {} bytes]", self.0.len()))
     }
 }
 
 impl fmt::Debug for Event {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::GetQueryResponse { query_id, data } => f
                 .debug_struct("GetQueryResponse")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub enum Event {
 
 struct DataFmt<'a>(&'a [u8]);
 
-impl<'a> fmt::Debug for DataFmt<'a> {
+impl fmt::Debug for DataFmt<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("[... {} bytes]", self.0.len()))
     }
@@ -88,7 +88,7 @@ impl fmt::Debug for Event {
             Self::GetQueryResponse { query_id, data } => f
                 .debug_struct("GetQueryResponse")
                 .field("query_id", query_id)
-                .field("data", &DataFmt(&data))
+                .field("data", &DataFmt(data))
                 .finish(),
             Self::GetQueryError { query_id, error } => f
                 .debug_struct("GetQueryError")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ where
 }
 
 /// Event produced by [`Behaviour`].
-#[derive(Debug)]
 pub enum Event {
     /// Requested block has been successfuly retrieved
     GetQueryResponse {
@@ -72,6 +71,29 @@ pub enum Event {
         /// Error that occurred when getting the data
         error: Error,
     },
+}
+
+impl core::fmt::Debug for Event {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GetQueryResponse { query_id, data } => {
+                let data_str = if data.len() > 32 {
+                    format!("{:?}", data[..32].as_ref())
+                } else {
+                    format!("{:?}", data)
+                };
+                f.debug_struct("GetQueryResponse")
+                    .field("query_id", query_id)
+                    .field("data", &data_str)
+                    .finish()
+            }
+            Self::GetQueryError { query_id, error } => f
+                .debug_struct("GetQueryError")
+                .field("query_id", query_id)
+                .field("error", error)
+                .finish(),
+        }
+    }
 }
 
 /// Representation of all the errors that can occur when interacting with this crate.


### PR DESCRIPTION
This is more of a suggestion, if you don't think it's a good improvement we're all good. 

However, while debugging events in the polka-storage project, I got absolutely spammed by the data field (our payload has a length of ~262k).

I picked 32 more or less at random, but of course, I'm open to suggestions.