### PR TITLE
fix: remove multihash digest from the prefix

### DIFF
--- a/src/cid_prefix.rs
+++ b/src/cid_prefix.rs
@@ -16,7 +16,6 @@ pub(crate) struct CidPrefix {
 }
 
 impl CidPrefix {
-    #[allow(dead_code)]
     pub(crate) fn from_cid<const S: usize>(cid: &CidGeneric<S>) -> CidPrefix {
         CidPrefix {
             version: cid.version(),
@@ -52,7 +51,6 @@ impl CidPrefix {
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         match self.version {
             // CIDv0 is a naked multihash that with fixed code and size

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,6 +18,7 @@ use libp2p_swarm::{
 use smallvec::SmallVec;
 use tracing::{debug, trace};
 
+use crate::cid_prefix::CidPrefix;
 use crate::incoming_stream::ServerMessage;
 use crate::message::Codec;
 use crate::proto::message::{
@@ -234,7 +235,7 @@ where
                 blocks_ready_for_peer
                     .entry(peer)
                     .or_default()
-                    .push((cid.to_bytes(), data.clone()))
+                    .push((CidPrefix::from_cid(&cid).to_bytes(), data.clone()))
             }
         }
 
@@ -516,7 +517,13 @@ mod tests {
         let ToHandlerEvent::QueueOutgoingMessages(msgs) = event else {
             panic!("Invalid handler message type ");
         };
-        assert_eq!(msgs, vec![(cid.into(), data.as_bytes().to_vec())]);
+        assert_eq!(
+            msgs,
+            vec![(
+                CidPrefix::from_cid(&cid).to_bytes(),
+                data.as_bytes().to_vec()
+            )]
+        );
     }
 
     #[tokio::test]
@@ -555,7 +562,13 @@ mod tests {
         let ToHandlerEvent::QueueOutgoingMessages(msgs) = event else {
             panic!("Invalid handler message type ");
         };
-        assert_eq!(msgs, vec![(cid.into(), data.as_bytes().to_vec())]);
+        assert_eq!(
+            msgs,
+            vec![(
+                CidPrefix::from_cid(&cid).to_bytes(),
+                data.as_bytes().to_vec()
+            )]
+        );
     }
 
     async fn new_server() -> ServerBehaviour<64, InMemoryBlockstore<64>> {


### PR DESCRIPTION
Removing the cd multihash digest from the message.  It's not needed and not expected by some implementations.
https://github.com/ipfs/helia/blob/c0bf36eb45ae0551a1c406e5b806d01425abb1f9/packages/bitswap/src/want-list.ts#L371